### PR TITLE
feat: implement smart indentation for paste operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Advanced yank history manager with cycling support for Vim/Neovim powered by den
 - **Multi-register support**: Track history for multiple registers
 - **Smart highlighting**: Visual feedback during paste cycling
 - **Database-backed storage**: Efficient storage with SQLite
+- **Smart indentation**: Automatically adjusts indentation when pasting line-wise content
 
 ## Requirements
 
@@ -59,28 +60,29 @@ nmap <C-p> <Plug>(haritsuke-prev)
 " Replace operator
 nmap gr <Plug>(haritsuke-replace)
 xmap gr <Plug>(haritsuke-replace)
+
+" Toggle smart indent while cycling (optional)
+nmap <C-i> <Plug>(haritsuke-toggle-smart-indent)
 ```
 
 Using Neovim Lua:
 
 ```lua
 -- Enhanced paste commands with history cycling
-vim.keymap.set('n', 'p', '<Plug>(haritsuke-p)')
-vim.keymap.set('n', 'P', '<Plug>(haritsuke-P)')
-vim.keymap.set('n', 'gp', '<Plug>(haritsuke-gp)')
-vim.keymap.set('n', 'gP', '<Plug>(haritsuke-gP)')
-vim.keymap.set('x', 'p', '<Plug>(haritsuke-p)')
-vim.keymap.set('x', 'P', '<Plug>(haritsuke-P)')
-vim.keymap.set('x', 'gp', '<Plug>(haritsuke-gp)')
-vim.keymap.set('x', 'gP', '<Plug>(haritsuke-gP)')
+vim.keymap.set({'n', 'x'}, 'p', '<Plug>(haritsuke-p)')
+vim.keymap.set({'n', 'x'}, 'P', '<Plug>(haritsuke-P)')
+vim.keymap.set({'n', 'x'}, 'gp', '<Plug>(haritsuke-gp)')
+vim.keymap.set({'n', 'x'}, 'gP', '<Plug>(haritsuke-gP)')
 
 -- Cycle through yank history after pasting
 vim.keymap.set('n', '<C-n>', '<Plug>(haritsuke-next)')
 vim.keymap.set('n', '<C-p>', '<Plug>(haritsuke-prev)')
 
 -- Replace operator
-vim.keymap.set('n', 'gr', '<Plug>(haritsuke-replace)')
-vim.keymap.set('x', 'gr', '<Plug>(haritsuke-replace)')
+vim.keymap.set({'n', 'x'}, 'gr', '<Plug>(haritsuke-replace)')
+
+-- Toggle smart indent while cycling (optional)
+vim.keymap.set('n', '<C-i>', '<Plug>(haritsuke-toggle-smart-indent)')
 ```
 
 ### How it works
@@ -128,7 +130,8 @@ let g:haritsuke_config = {
   \ 'register_keys': 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"-=.:%/#*+~_',
   \ 'debug': v:false,           " Enable debug logging
   \ 'use_region_hl': v:true,    " Enable highlight during paste cycling
-  \ 'region_hl_groupname': 'HaritsukeRegion'  " Highlight group name
+  \ 'region_hl_groupname': 'HaritsukeRegion',  " Highlight group name
+  \ 'smart_indent': v:true      " Enable smart indentation adjustment
   \ }
 ```
 
@@ -142,7 +145,8 @@ vim.g.haritsuke_config = {
   register_keys = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"-=.:%/#*+~_',
   debug = false,             -- Enable debug logging
   use_region_hl = true,      -- Enable highlight during paste cycling
-  region_hl_groupname = 'HaritsukeRegion'  -- Highlight group name
+  region_hl_groupname = 'HaritsukeRegion',  -- Highlight group name
+  smart_indent = true        -- Enable smart indentation adjustment
 }
 ```
 
@@ -155,6 +159,7 @@ vim.g.haritsuke_config = {
 - **debug**: Enable debug logging for troubleshooting (default: false)
 - **use_region_hl**: Show visual highlight of pasted region during cycling (default: true)
 - **region_hl_groupname**: Vim highlight group for paste region highlighting (default: 'HaritsukeRegion')
+- **smart_indent**: Enable smart indentation adjustment for line-wise paste operations. Automatically adjusts pasted lines to match current context (default: true)
 
 ### Highlight customization
 
@@ -165,6 +170,36 @@ highlight HaritsukeRegion guibg=#3e4452 ctermbg=238
 ```
 
 ## Advanced features
+
+### Paste without smart indent
+
+If you need to paste with original indentation preserved, you can use the special mappings:
+
+Using Vim script:
+
+```vim
+" Use <Leader>p for paste without smart indent
+nmap <Leader>p <Plug>(haritsuke-p-no-smart-indent)
+nmap <Leader>P <Plug>(haritsuke-P-no-smart-indent)
+nmap <Leader>gp <Plug>(haritsuke-gp-no-smart-indent)
+nmap <Leader>gP <Plug>(haritsuke-gP-no-smart-indent)
+xmap <Leader>p <Plug>(haritsuke-p-no-smart-indent)
+xmap <Leader>P <Plug>(haritsuke-P-no-smart-indent)
+xmap <Leader>gp <Plug>(haritsuke-gp-no-smart-indent)
+xmap <Leader>gP <Plug>(haritsuke-gP-no-smart-indent)
+```
+
+Using Neovim Lua:
+
+```lua
+-- Use <Leader>p for paste without smart indent
+vim.keymap.set({'n', 'x'}, '<Leader>p', '<Plug>(haritsuke-p-no-smart-indent)')
+vim.keymap.set({'n', 'x'}, '<Leader>P', '<Plug>(haritsuke-P-no-smart-indent)')
+vim.keymap.set({'n', 'x'}, '<Leader>gp', '<Plug>(haritsuke-gp-no-smart-indent)')
+vim.keymap.set({'n', 'x'}, '<Leader>gP', '<Plug>(haritsuke-gP-no-smart-indent)')
+```
+
+These mappings temporarily disable smart indentation for the paste operation.
 
 ### Multi-register support
 

--- a/autoload/haritsuke.vim
+++ b/autoload/haritsuke.vim
@@ -119,3 +119,39 @@ function! haritsuke#list() abort
     return []
   endtry
 endfunction
+
+function! haritsuke#toggle_smart_indent() abort
+  if !denops#plugin#is_loaded('haritsuke')
+    return
+  endif
+
+  call denops#plugin#wait('haritsuke')
+  call s:ensure_initialized()
+
+  try
+    call denops#request('haritsuke', 'toggleSmartIndent', [])
+  catch
+    " Ignore errors
+  endtry
+endfunction
+
+function! haritsuke#do_paste_no_smart_indent(mode, vmode) abort
+  call denops#plugin#wait('haritsuke')
+  
+  " Temporarily disable smart_indent
+  let l:saved_smart_indent = get(g:haritsuke_config, 'smart_indent', v:true)
+  let g:haritsuke_config.smart_indent = v:false
+  
+  " Update config hash to force re-initialization
+  let s:last_config_hash = ''
+  
+  try
+    " Call regular paste function
+    call haritsuke#do_paste(a:mode, a:vmode)
+  finally
+    " Restore original smart_indent setting
+    let g:haritsuke_config.smart_indent = l:saved_smart_indent
+    " Update config hash again
+    let s:last_config_hash = ''
+  endtry
+endfunction

--- a/denops/haritsuke/constants.ts
+++ b/denops/haritsuke/constants.ts
@@ -72,4 +72,5 @@ export const CONFIG_DEFAULTS = {
   DEBUG: false,
   USE_REGION_HL: true,
   REGION_HL_GROUPNAME: "HaritsukeRegion",
+  SMART_INDENT: true,
 } as const

--- a/denops/haritsuke/main.ts
+++ b/denops/haritsuke/main.ts
@@ -20,5 +20,6 @@ export function main(denops: Denops): void {
     doReplaceOperator: api.doReplaceOperator,
     isActive: api.isActive,
     listHistory: api.listHistory,
+    toggleSmartIndent: api.toggleSmartIndent,
   }
 }

--- a/denops/haritsuke/state/plugin-state.ts
+++ b/denops/haritsuke/state/plugin-state.ts
@@ -52,6 +52,7 @@ export const createPluginState = (): PluginState => {
       debug: CONFIG_DEFAULTS.DEBUG,
       use_region_hl: CONFIG_DEFAULTS.USE_REGION_HL,
       region_hl_groupname: CONFIG_DEFAULTS.REGION_HL_GROUPNAME,
+      smart_indent: CONFIG_DEFAULTS.SMART_INDENT,
     },
     vimApi: null,
     fileSystemApi: null,

--- a/denops/haritsuke/test/api-prepare-paste_test.ts
+++ b/denops/haritsuke/test/api-prepare-paste_test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for api.ts preparePaste function
+ * Testing smart indent functionality for initial paste
+ */
+
+import { assertEquals, describe, it, spy } from "../deps/test.ts"
+import { createApi } from "../api/api.ts"
+import type { PluginState } from "../state/plugin-state.ts"
+import type { Denops } from "../deps/denops.ts"
+import { createMockVimApi } from "../vim/vim-api.ts"
+import { createMockPluginState } from "./test-helpers.ts"
+
+// Mock Denops with proper fn module
+const createMockDenops = (): Denops => {
+  return {
+    cmd: spy(() => Promise.resolve()),
+    eval: spy((expr: string) => {
+      if (expr === "b:changedtick") return Promise.resolve(100)
+      return Promise.resolve(1)
+    }),
+    call: spy((fn: string, ...args: unknown[]) => {
+      if (fn === "bufnr" && args[0] === "%") return Promise.resolve(1)
+      if (fn === "getpos" && args[0] === ".") return Promise.resolve([0, 10, 5, 0])
+      if (fn === "line" && args[0] === ".") return Promise.resolve(10)
+      if (fn === "line" && args[0] === "$") return Promise.resolve(100)
+      if (fn === "getline" && args[0] === ".") return Promise.resolve("  const result = ")
+      if (fn === "getpos") return Promise.resolve([0, 1, 1, 0])
+      if (fn === "undotree") return Promise.resolve({ seq_cur: 0, seq_last: 0, entries: [] })
+      return Promise.resolve()
+    }),
+    batch: spy(() => Promise.resolve()),
+    dispatch: spy(() => Promise.resolve()),
+  } as unknown as Denops
+}
+
+describe("api preparePaste", () => {
+  describe("smart indent for initial paste", () => {
+    it("adjusts indent for line-wise paste based on current line", async () => {
+      // Track setreg calls
+      const setregCalls: Array<{ register: string; content: string; regtype: string }> = []
+      
+      const mockVimApi = createMockVimApi({
+        getreg: (register: string) => {
+          if (register === '"') {
+            return Promise.resolve("    function test() {\n      return 42;\n    }")
+          }
+          return Promise.resolve("")
+        },
+        getregtype: (register: string) => {
+          if (register === '"') {
+            return Promise.resolve("V") // Line-wise
+          }
+          return Promise.resolve("v")
+        },
+        setreg: spy((register: string, content: string, regtype: string) => {
+          setregCalls.push({ register, content, regtype })
+          return Promise.resolve()
+        }),
+        getline: () => Promise.resolve("  const result = "), // Current line has 2 spaces indent
+        line: () => Promise.resolve(10),
+      })
+      
+      // Create mock rounder
+      const mockRounder = {
+        isActive: () => false,
+        start: spy(() => Promise.resolve()),
+        setBeforePasteCursorPos: spy(() => {}),
+        setUndoFilePath: spy(() => {}),
+      }
+      
+      const mockRounderManager = {
+        getRounder: () => Promise.resolve(mockRounder),
+      }
+      
+      const state = createMockPluginState({
+        config: {
+          persist_path: "/tmp",
+          max_entries: 100,
+          max_data_size: 1024,
+          register_keys: "",
+          debug: true,
+          use_region_hl: false,
+          region_hl_groupname: "HaritsukeRegion",
+          smart_indent: true, // Enable smart indent
+        },
+        vimApi: mockVimApi,
+        rounderManager: mockRounderManager as any,
+        cache: {
+          getAll: () => [],
+        } as any,
+        pasteHandler: {} as any,
+      })
+      
+      const denops = createMockDenops()
+      const api = createApi(denops, state)
+      
+      // Execute preparePaste
+      const result = await api.preparePaste({
+        mode: "p",
+        vmode: "n",
+        count: 1,
+        register: '"',
+      })
+      
+      // Verify paste command is returned
+      assertEquals(result, 'normal! ""1p')
+      
+      // Verify that setreg was called with adjusted content
+      assertEquals(setregCalls.length, 1)
+      assertEquals(setregCalls[0].register, '"')
+      assertEquals(setregCalls[0].content, "  function test() {\n    return 42;\n  }")
+      assertEquals(setregCalls[0].regtype, "V")
+    })
+    
+    it("skips adjustment for character-wise paste", async () => {
+      const setregCalls: Array<{ register: string; content: string; regtype: string }> = []
+      
+      const mockVimApi = createMockVimApi({
+        getreg: (register: string) => {
+          if (register === '"') {
+            return Promise.resolve("test content")
+          }
+          return Promise.resolve("")
+        },
+        getregtype: (register: string) => {
+          if (register === '"') {
+            return Promise.resolve("v") // Character-wise
+          }
+          return Promise.resolve("v")
+        },
+        setreg: spy((register: string, content: string, regtype: string) => {
+          setregCalls.push({ register, content, regtype })
+          return Promise.resolve()
+        }),
+      })
+      
+      const mockRounder = {
+        isActive: () => false,
+        start: spy(() => Promise.resolve()),
+        setBeforePasteCursorPos: spy(() => {}),
+        setUndoFilePath: spy(() => {}),
+      }
+      
+      const mockRounderManager = {
+        getRounder: () => Promise.resolve(mockRounder),
+      }
+      
+      const state = createMockPluginState({
+        config: {
+          persist_path: "/tmp",
+          max_entries: 100,
+          max_data_size: 1024,
+          register_keys: "",
+          debug: true,
+          use_region_hl: false,
+          region_hl_groupname: "HaritsukeRegion",
+          smart_indent: true, // Enable smart indent
+        },
+        vimApi: mockVimApi,
+        rounderManager: mockRounderManager as any,
+        cache: {
+          getAll: () => [],
+        } as any,
+        pasteHandler: {} as any,
+      })
+      
+      const denops = createMockDenops()
+      const api = createApi(denops, state)
+      
+      await api.preparePaste({
+        mode: "p",
+        vmode: "n",
+        count: 1,
+        register: '"',
+      })
+      
+      // Verify that setreg was NOT called (no adjustment for character-wise)
+      assertEquals(setregCalls.length, 0)
+    })
+    
+    it("skips adjustment when smart_indent is disabled", async () => {
+      const setregCalls: Array<{ register: string; content: string; regtype: string }> = []
+      
+      const mockVimApi = createMockVimApi({
+        getreg: (register: string) => {
+          if (register === '"') {
+            return Promise.resolve("    function test() {\n      return 42;\n    }")
+          }
+          return Promise.resolve("")
+        },
+        getregtype: (register: string) => {
+          if (register === '"') {
+            return Promise.resolve("V") // Line-wise
+          }
+          return Promise.resolve("v")
+        },
+        setreg: spy((register: string, content: string, regtype: string) => {
+          setregCalls.push({ register, content, regtype })
+          return Promise.resolve()
+        }),
+      })
+      
+      const mockRounder = {
+        isActive: () => false,
+        start: spy(() => Promise.resolve()),
+        setBeforePasteCursorPos: spy(() => {}),
+        setUndoFilePath: spy(() => {}),
+      }
+      
+      const mockRounderManager = {
+        getRounder: () => Promise.resolve(mockRounder),
+      }
+      
+      const state = createMockPluginState({
+        config: {
+          persist_path: "/tmp",
+          max_entries: 100,
+          max_data_size: 1024,
+          register_keys: "",
+          debug: true,
+          use_region_hl: false,
+          region_hl_groupname: "HaritsukeRegion",
+          smart_indent: false, // Disable smart indent
+        },
+        vimApi: mockVimApi,
+        rounderManager: mockRounderManager as any,
+        cache: {
+          getAll: () => [],
+        } as any,
+        pasteHandler: {} as any,
+      })
+      
+      const denops = createMockDenops()
+      const api = createApi(denops, state)
+      
+      await api.preparePaste({
+        mode: "p",
+        vmode: "n",
+        count: 1,
+        register: '"',
+      })
+      
+      // Verify that setreg was NOT called (no adjustment when disabled)
+      assertEquals(setregCalls.length, 0)
+    })
+    
+    it("handles errors gracefully and continues with original content", async () => {
+      const mockVimApi = createMockVimApi({
+        getreg: () => Promise.reject(new Error("Test error")),
+      })
+      
+      const mockRounder = {
+        isActive: () => false,
+        start: spy(() => Promise.resolve()),
+        setBeforePasteCursorPos: spy(() => {}),
+        setUndoFilePath: spy(() => {}),
+      }
+      
+      const mockRounderManager = {
+        getRounder: () => Promise.resolve(mockRounder),
+      }
+      
+      const state = createMockPluginState({
+        config: {
+          persist_path: "/tmp",
+          max_entries: 100,
+          max_data_size: 1024,
+          register_keys: "",
+          debug: true,
+          use_region_hl: false,
+          region_hl_groupname: "HaritsukeRegion",
+          smart_indent: true,
+        },
+        vimApi: mockVimApi,
+        rounderManager: mockRounderManager as any,
+        cache: {
+          getAll: () => [],
+        } as any,
+        pasteHandler: {} as any,
+      })
+      
+      const denops = createMockDenops()
+      const api = createApi(denops, state)
+      
+      // Should not throw error
+      const result = await api.preparePaste({
+        mode: "p",
+        vmode: "n",
+        count: 1,
+        register: '"',
+      })
+      
+      // Verify paste command is returned
+      assertEquals(result, 'normal! ""1p')
+    })
+  })
+})

--- a/denops/haritsuke/test/api-toggle-smart-indent_test.ts
+++ b/denops/haritsuke/test/api-toggle-smart-indent_test.ts
@@ -1,0 +1,314 @@
+/**
+ * Tests for toggleSmartIndent API function
+ */
+
+import { assertEquals, assertSpyCall, describe, it, spy } from "../deps/test.ts"
+import { createApi } from "../api/api.ts"
+import type { PluginState } from "../state/plugin-state.ts"
+import type { Denops } from "../deps/denops.ts"
+import { createMockPluginState } from "./test-helpers.ts"
+import type { YankEntry } from "../types.ts"
+
+// Mock Denops
+const createMockDenops = (): Denops => {
+  return {
+    cmd: spy(() => Promise.resolve()),
+    eval: spy((expr: string) => {
+      if (expr === "b:changedtick") return Promise.resolve(100)
+      return Promise.resolve(1)
+    }),
+    call: spy((fn: string, ...args: unknown[]) => {
+      if (fn === "bufnr" && args[0] === "%") return Promise.resolve(1)
+      return Promise.resolve()
+    }),
+    batch: spy(() => Promise.resolve()),
+    dispatch: spy(() => Promise.resolve()),
+  } as unknown as Denops
+}
+
+describe("api toggleSmartIndent", () => {
+  it("toggles smart_indent setting when rounder is active", async () => {
+    // Track applyHistoryEntry calls
+    const applyHistoryEntrySpy = spy(() => Promise.resolve())
+    
+    // Create mock rounder
+    const mockRounder = {
+      isActive: () => true,
+      getCurrentEntry: () => ({
+        id: "1",
+        content: "    test content\n    second line",
+        regtype: "V",
+        timestamp: 1000,
+      } as YankEntry),
+      getPasteInfo: () => ({
+        mode: "p" as "p",
+        count: 1,
+        register: '"',
+        visualMode: false,
+      }),
+      isFirstCycle: () => false,
+      getUndoFilePath: () => "/tmp/undo.txt",
+    }
+    
+    const mockRounderManager = {
+      getRounder: () => Promise.resolve(mockRounder),
+    }
+    
+    const state = createMockPluginState({
+      config: {
+        persist_path: "/tmp",
+        max_entries: 100,
+        max_data_size: 1024,
+        register_keys: "",
+        debug: true,
+        use_region_hl: false,
+        region_hl_groupname: "HaritsukeRegion",
+        smart_indent: true, // Initial state: enabled
+      },
+      rounderManager: mockRounderManager as any,
+      pasteHandler: {
+        applyHistoryEntry: applyHistoryEntrySpy,
+      } as any,
+    })
+    
+    const denops = createMockDenops()
+    const api = createApi(denops, state)
+    
+    // Initial state should be true
+    assertEquals(state.config.smart_indent, true)
+    
+    // Toggle smart indent
+    await api.toggleSmartIndent({})
+    
+    // Should toggle to false
+    assertEquals(state.config.smart_indent, false)
+    
+    // Should call applyHistoryEntry with correct parameters
+    assertSpyCall(applyHistoryEntrySpy, 0, {
+      args: [
+        denops,
+        {
+          id: "1",
+          content: "    test content\n    second line",
+          regtype: "V",
+          timestamp: 1000,
+        },
+        1, // undoSeq (not first cycle)
+        {
+          mode: "p",
+          count: 1,
+          register: '"',
+          visualMode: false,
+        },
+        "/tmp/undo.txt",
+        mockRounder,
+      ],
+    })
+    
+    // Toggle again
+    await api.toggleSmartIndent({})
+    
+    // Should toggle back to true
+    assertEquals(state.config.smart_indent, true)
+    
+    // Should call applyHistoryEntry again
+    assertEquals(applyHistoryEntrySpy.calls.length, 2)
+  })
+  
+  it("does nothing when rounder is not active", async () => {
+    const applyHistoryEntrySpy = spy(() => Promise.resolve())
+    
+    // Create mock rounder that is not active
+    const mockRounder = {
+      isActive: () => false,
+    }
+    
+    const mockRounderManager = {
+      getRounder: () => Promise.resolve(mockRounder),
+    }
+    
+    const state = createMockPluginState({
+      config: {
+        persist_path: "/tmp",
+        max_entries: 100,
+        max_data_size: 1024,
+        register_keys: "",
+        debug: true,
+        use_region_hl: false,
+        region_hl_groupname: "HaritsukeRegion",
+        smart_indent: true,
+      },
+      rounderManager: mockRounderManager as any,
+      pasteHandler: {
+        applyHistoryEntry: applyHistoryEntrySpy,
+      } as any,
+    })
+    
+    const denops = createMockDenops()
+    const api = createApi(denops, state)
+    
+    // Initial state
+    const initialState = state.config.smart_indent
+    
+    // Toggle smart indent
+    await api.toggleSmartIndent({})
+    
+    // Should not change state
+    assertEquals(state.config.smart_indent, initialState)
+    
+    // Should not call applyHistoryEntry
+    assertEquals(applyHistoryEntrySpy.calls.length, 0)
+  })
+  
+  it("handles missing rounderManager gracefully", async () => {
+    const state = createMockPluginState({
+      config: {
+        persist_path: "/tmp",
+        max_entries: 100,
+        max_data_size: 1024,
+        register_keys: "",
+        debug: true,
+        use_region_hl: false,
+        region_hl_groupname: "HaritsukeRegion",
+        smart_indent: true,
+      },
+      rounderManager: null as any,
+      pasteHandler: {} as any,
+    })
+    
+    const denops = createMockDenops()
+    const api = createApi(denops, state)
+    
+    // Should not throw error
+    await api.toggleSmartIndent({})
+    
+    // State should remain unchanged
+    assertEquals(state.config.smart_indent, true)
+  })
+  
+  it("handles missing current entry gracefully", async () => {
+    const applyHistoryEntrySpy = spy(() => Promise.resolve())
+    
+    // Create mock rounder with no current entry
+    const mockRounder = {
+      isActive: () => true,
+      getCurrentEntry: () => null,
+      getPasteInfo: () => ({
+        mode: "p" as "p",
+        count: 1,
+        register: '"',
+        visualMode: false,
+      }),
+      isFirstCycle: () => false,
+      getUndoFilePath: () => null,
+    }
+    
+    const mockRounderManager = {
+      getRounder: () => Promise.resolve(mockRounder),
+    }
+    
+    const state = createMockPluginState({
+      config: {
+        persist_path: "/tmp",
+        max_entries: 100,
+        max_data_size: 1024,
+        register_keys: "",
+        debug: true,
+        use_region_hl: false,
+        region_hl_groupname: "HaritsukeRegion",
+        smart_indent: true,
+      },
+      rounderManager: mockRounderManager as any,
+      pasteHandler: {
+        applyHistoryEntry: applyHistoryEntrySpy,
+      } as any,
+    })
+    
+    const denops = createMockDenops()
+    const api = createApi(denops, state)
+    
+    // Initial state
+    const initialState = state.config.smart_indent
+    
+    // Toggle smart indent
+    await api.toggleSmartIndent({})
+    
+    // Should toggle the setting even though no entry to re-apply
+    assertEquals(state.config.smart_indent, !initialState)
+    
+    // Should not call applyHistoryEntry due to missing entry
+    assertEquals(applyHistoryEntrySpy.calls.length, 0)
+  })
+  
+  it("correctly handles first cycle (undoSeq = 0)", async () => {
+    const applyHistoryEntrySpy = spy(() => Promise.resolve())
+    
+    // Create mock rounder on first cycle
+    const mockRounder = {
+      isActive: () => true,
+      getCurrentEntry: () => ({
+        id: "1",
+        content: "test",
+        regtype: "V",
+        timestamp: 1000,
+      } as YankEntry),
+      getPasteInfo: () => ({
+        mode: "p" as "p",
+        count: 1,
+        register: '"',
+        visualMode: false,
+      }),
+      isFirstCycle: () => true, // First cycle
+      getUndoFilePath: () => null,
+    }
+    
+    const mockRounderManager = {
+      getRounder: () => Promise.resolve(mockRounder),
+    }
+    
+    const state = createMockPluginState({
+      config: {
+        persist_path: "/tmp",
+        max_entries: 100,
+        max_data_size: 1024,
+        register_keys: "",
+        debug: true,
+        use_region_hl: false,
+        region_hl_groupname: "HaritsukeRegion",
+        smart_indent: true,
+      },
+      rounderManager: mockRounderManager as any,
+      pasteHandler: {
+        applyHistoryEntry: applyHistoryEntrySpy,
+      } as any,
+    })
+    
+    const denops = createMockDenops()
+    const api = createApi(denops, state)
+    
+    // Toggle smart indent
+    await api.toggleSmartIndent({})
+    
+    // Should call applyHistoryEntry with undoSeq = 0
+    assertSpyCall(applyHistoryEntrySpy, 0, {
+      args: [
+        denops,
+        {
+          id: "1",
+          content: "test",
+          regtype: "V",
+          timestamp: 1000,
+        },
+        0, // undoSeq should be 0 for first cycle
+        {
+          mode: "p",
+          count: 1,
+          register: '"',
+          visualMode: false,
+        },
+        null,
+        mockRounder,
+      ],
+    })
+  })
+})

--- a/denops/haritsuke/test/indent-adjuster_test.ts
+++ b/denops/haritsuke/test/indent-adjuster_test.ts
@@ -1,0 +1,268 @@
+import { assertEquals, describe, it } from "../deps/test.ts";
+import {
+  adjustIndent,
+  detectMinIndent,
+  getIndentText,
+  adjustContentIndentSmart,
+} from "../utils/indent-adjuster.ts";
+import { createMockVimApi } from "../vim/vim-api.ts";
+
+describe("indent-adjuster", () => {
+  describe("detectMinIndent", () => {
+    it("should detect minimum indent from lines", () => {
+      const lines = [
+        "    function test() {",
+        "      const a = 1;",
+        "      if (a) {",
+        "        console.log(a);",
+        "      }",
+        "    }",
+      ];
+      assertEquals(detectMinIndent(lines), "    ");
+    });
+
+    it("should ignore empty lines", () => {
+      const lines = [
+        "    function test() {",
+        "",
+        "      const a = 1;",
+        "",
+        "    }",
+      ];
+      assertEquals(detectMinIndent(lines), "    ");
+    });
+
+    it("should return empty string when no indent", () => {
+      const lines = [
+        "function test() {",
+        "const a = 1;",
+        "}",
+      ];
+      assertEquals(detectMinIndent(lines), "");
+    });
+
+    it("should handle mixed tabs and spaces", () => {
+      const lines = [
+        "\t\tfunction test() {",
+        "\t\t\tconst a = 1;",
+        "\t\t}",
+      ];
+      assertEquals(detectMinIndent(lines), "\t\t");
+    });
+  });
+
+  describe("getIndentText", () => {
+    it("should generate indent text with spaces", () => {
+      assertEquals(getIndentText(2, 4, false), "        ");
+    });
+
+    it("should generate indent text with tabs", () => {
+      assertEquals(getIndentText(2, 4, true), "\t\t");
+    });
+
+    it("should handle zero indent", () => {
+      assertEquals(getIndentText(0, 4, false), "");
+    });
+  });
+
+  describe("adjustIndent", () => {
+    it("should adjust indent for pasted lines", () => {
+      const lines = [
+        "    function test() {",
+        "      const a = 1;",
+        "      return a;",
+        "    }",
+      ];
+      const baseIndent = "  ";
+      const result = adjustIndent(lines, baseIndent);
+      assertEquals(result, [
+        "  function test() {",
+        "    const a = 1;",
+        "    return a;",
+        "  }",
+      ]);
+    });
+
+    it("should preserve relative indentation", () => {
+      const lines = [
+        "  if (condition) {",
+        "    doSomething();",
+        "      .then(() => {",
+        "        console.log('done');",
+        "      });",
+        "  }",
+      ];
+      const baseIndent = "    ";
+      const result = adjustIndent(lines, baseIndent);
+      assertEquals(result, [
+        "    if (condition) {",
+        "      doSomething();",
+        "        .then(() => {",
+        "          console.log('done');",
+        "        });",
+        "    }",
+      ]);
+    });
+
+    it("should handle empty lines correctly", () => {
+      const lines = [
+        "    function test() {",
+        "",
+        "      const a = 1;",
+        "",
+        "    }",
+      ];
+      const baseIndent = "";
+      const result = adjustIndent(lines, baseIndent);
+      assertEquals(result, [
+        "function test() {",
+        "",
+        "  const a = 1;",
+        "",
+        "}",
+      ]);
+    });
+
+    it("should handle lines with no initial indent", () => {
+      const lines = [
+        "function test() {",
+        "  const a = 1;",
+        "}",
+      ];
+      const baseIndent = "  ";
+      const result = adjustIndent(lines, baseIndent);
+      assertEquals(result, [
+        "  function test() {",
+        "    const a = 1;",
+        "  }",
+      ]);
+    });
+  });
+
+  describe("adjustContentIndentSmart", () => {
+    it("should adjust content based on current line indent", async () => {
+      const mockVimApi = createMockVimApi({
+        getline: () => Promise.resolve("  const result = "),
+        line: () => Promise.resolve(10),
+      });
+
+      const content = "function test() {\n  return 42;\n}";
+      const pasteInfo = { mode: "p" as "p", count: 1, register: '"' };
+
+      const result = await adjustContentIndentSmart(content, pasteInfo, mockVimApi);
+      
+      assertEquals(result, "  function test() {\n    return 42;\n  }");
+    });
+
+    it("should calculate indent when current line has no indent and mode is p", async () => {
+      const mockVimApi = createMockVimApi({
+        getline: () => Promise.resolve(""), // No indent on current line
+        line: () => Promise.resolve(10),
+        getwinvar: (_, name: string) => {
+          if (name === "&shiftwidth") return Promise.resolve(2);
+          if (name === "&expandtab") return Promise.resolve(1);
+          return Promise.resolve(0);
+        },
+        getbufvar: (_, name: string) => {
+          if (name === "&indentexpr") return Promise.resolve(""); // No indentexpr
+          return Promise.resolve(0);
+        },
+        cmd: () => Promise.resolve(),
+        eval: () => Promise.resolve(0),
+      });
+
+      const content = "function test() {\n  return 42;\n}";
+      const pasteInfo = { mode: "p" as "p", count: 1, register: '"' };
+
+      const result = await adjustContentIndentSmart(content, pasteInfo, mockVimApi);
+      
+      // Should keep original content when no indent is calculated
+      assertEquals(result, "function test() {\n  return 42;\n}");
+    });
+
+    it("should use indentexpr when available", async () => {
+      const mockVimApi = createMockVimApi({
+        getline: () => Promise.resolve(""), // No indent on current line
+        line: () => Promise.resolve(10),
+        getwinvar: (_, name: string) => {
+          if (name === "&shiftwidth") return Promise.resolve(4);
+          if (name === "&expandtab") return Promise.resolve(1);
+          return Promise.resolve(0);
+        },
+        getbufvar: (_, name: string) => {
+          if (name === "&indentexpr") return Promise.resolve("GetVimIndent()");
+          return Promise.resolve(0);
+        },
+        cmd: () => Promise.resolve(),
+        eval: (expr: string) => {
+          if (expr.includes("indent(")) return Promise.resolve(8); // 2 levels * 4 spaces
+          return Promise.resolve(0);
+        },
+      });
+
+      const content = "function test() {\n  return 42;\n}";
+      const pasteInfo = { mode: "p" as "p", count: 1, register: '"' };
+
+      const result = await adjustContentIndentSmart(content, pasteInfo, mockVimApi);
+      
+      assertEquals(result, "        function test() {\n          return 42;\n        }");
+    });
+
+    it("should use tabs when expandtab is off", async () => {
+      const mockVimApi = createMockVimApi({
+        getline: () => Promise.resolve(""), // No indent on current line
+        line: () => Promise.resolve(10),
+        getwinvar: (_, name: string) => {
+          if (name === "&shiftwidth") return Promise.resolve(4);
+          if (name === "&expandtab") return Promise.resolve(0); // Use tabs
+          return Promise.resolve(0);
+        },
+        getbufvar: (_, name: string) => {
+          if (name === "&indentexpr") return Promise.resolve("GetVimIndent()");
+          return Promise.resolve(0);
+        },
+        cmd: () => Promise.resolve(),
+        eval: (expr: string) => {
+          if (expr.includes("indent(")) return Promise.resolve(8); // 2 levels
+          return Promise.resolve(0);
+        },
+      });
+
+      const content = "function test() {\n  return 42;\n}";
+      const pasteInfo = { mode: "p" as "p", count: 1, register: '"' };
+
+      const result = await adjustContentIndentSmart(content, pasteInfo, mockVimApi);
+      
+      assertEquals(result, "\t\tfunction test() {\n\t\t  return 42;\n\t\t}");
+    });
+
+    it("should return original content on error", async () => {
+      const mockVimApi = createMockVimApi({
+        getline: () => Promise.reject(new Error("Test error")),
+      });
+
+      const content = "function test() {\n  return 42;\n}";
+      const pasteInfo = { mode: "p" as "p", count: 1, register: '"' };
+
+      const result = await adjustContentIndentSmart(content, pasteInfo, mockVimApi);
+      
+      // Should return original content on error
+      assertEquals(result, content);
+    });
+
+    it("should not adjust when mode is not p and current line has no indent", async () => {
+      const mockVimApi = createMockVimApi({
+        getline: () => Promise.resolve(""), // No indent on current line
+        line: () => Promise.resolve(10),
+      });
+
+      const content = "function test() {\n  return 42;\n}";
+      const pasteInfo = { mode: "P" as "P", count: 1, register: '"' }; // Mode is P, not p
+
+      const result = await adjustContentIndentSmart(content, pasteInfo, mockVimApi);
+      
+      // Should adjust based on empty indent (remove all indent)
+      assertEquals(result, "function test() {\n  return 42;\n}");
+    });
+  });
+});

--- a/denops/haritsuke/test/paste-handler_test.ts
+++ b/denops/haritsuke/test/paste-handler_test.ts
@@ -229,5 +229,151 @@ describe("createPasteHandler", () => {
       )
       assertEquals(clearCalls.length, 1, "Should clear flag even on error")
     })
+
+    it("applies indent adjustment for line-wise paste", async () => {
+      const callbacks = createMockCallbacks()
+      
+      // Mock VimApi with necessary methods
+      const mockVimApi = createMockVimApi({
+        cmd: spy(() => Promise.resolve()),
+        setreg: spy(() => Promise.resolve()),
+        getreg: () => Promise.resolve("    function test() {\n      return 42;\n    }"),
+        setGlobalVar: spy(() => Promise.resolve()),
+        getline: () => Promise.resolve("  const result = "),
+        line: () => Promise.resolve(10),
+        getpos: () => Promise.resolve([0, 10, 16, 0]),
+        getwinvar: (_, name: string) => {
+          if (name === "&shiftwidth") return Promise.resolve(2)
+          if (name === "&expandtab") return Promise.resolve(1)
+          return Promise.resolve(0)
+        },
+        getbufvar: (_, name: string) => {
+          if (name === "&indentexpr") return Promise.resolve("")
+          return Promise.resolve(0)
+        },
+        eval: (expr: string) => {
+          if (expr.includes("indent(")) return Promise.resolve(4) // 2 indent levels * 2 spaces
+          return Promise.resolve(0)
+        },
+      })
+      
+      const pasteHandler = createPasteHandler(
+        null,
+        { useRegionHl: false, smartIndent: true },
+        mockVimApi,
+        callbacks,
+      )
+      
+      const entry: YankEntry = {
+        id: "1",
+        content: "    function test() {\n      return 42;\n    }",
+        regtype: "V", // Line-wise
+        timestamp: 100,
+      }
+      
+      const rounder = createRounder(null)
+      
+      await pasteHandler.applyHistoryEntry(
+        {} as Denops,
+        entry,
+        10,
+        { mode: "p", count: 1, register: '"' },
+        undefined,
+        rounder,
+      )
+      
+      // Verify that setreg was called with adjusted content
+      const setregCalls = (mockVimApi.setreg as ReturnType<typeof spy>).calls
+      assertEquals(setregCalls.length, 1)
+      assertEquals(setregCalls[0].args[0], '"')
+      // The content should be adjusted to have 2 spaces indent (matching current line)
+      assertEquals(
+        setregCalls[0].args[1],
+        "  function test() {\n    return 42;\n  }",
+      )
+      assertEquals(setregCalls[0].args[2], "V")
+    })
+
+    it("skips indent adjustment for character-wise paste", async () => {
+      const callbacks = createMockCallbacks()
+      
+      const mockVimApi = createMockVimApi({
+        cmd: spy(() => Promise.resolve()),
+        setreg: spy(() => Promise.resolve()),
+        getreg: () => Promise.resolve("test content"),
+        setGlobalVar: spy(() => Promise.resolve()),
+      })
+      
+      const pasteHandler = createPasteHandler(
+        null,
+        { useRegionHl: false, smartIndent: true },
+        mockVimApi,
+        callbacks,
+      )
+      
+      const entry: YankEntry = {
+        id: "1",
+        content: "test content",
+        regtype: "v", // Character-wise
+        timestamp: 100,
+      }
+      
+      const rounder = createRounder(null)
+      
+      await pasteHandler.applyHistoryEntry(
+        {} as Denops,
+        entry,
+        10,
+        { mode: "p", count: 1, register: '"' },
+        undefined,
+        rounder,
+      )
+      
+      // Verify that setreg was called with original content (no adjustment)
+      const setregCalls = (mockVimApi.setreg as ReturnType<typeof spy>).calls
+      assertEquals(setregCalls.length, 1)
+      assertEquals(setregCalls[0].args[1], "test content")
+    })
+
+    it("skips indent adjustment when smartIndent is disabled", async () => {
+      const callbacks = createMockCallbacks()
+      
+      const mockVimApi = createMockVimApi({
+        cmd: spy(() => Promise.resolve()),
+        setreg: spy(() => Promise.resolve()),
+        getreg: () => Promise.resolve("    function test() {\n      return 42;\n    }"),
+        setGlobalVar: spy(() => Promise.resolve()),
+      })
+      
+      const pasteHandler = createPasteHandler(
+        null,
+        { useRegionHl: false, smartIndent: false },
+        mockVimApi,
+        callbacks,
+      )
+      
+      const entry: YankEntry = {
+        id: "1",
+        content: "    function test() {\n      return 42;\n    }",
+        regtype: "V", // Line-wise
+        timestamp: 100,
+      }
+      
+      const rounder = createRounder(null)
+      
+      await pasteHandler.applyHistoryEntry(
+        {} as Denops,
+        entry,
+        10,
+        { mode: "p", count: 1, register: '"' },
+        undefined,
+        rounder,
+      )
+      
+      // Verify that setreg was called with original content (no adjustment)
+      const setregCalls = (mockVimApi.setreg as ReturnType<typeof spy>).calls
+      assertEquals(setregCalls.length, 1)
+      assertEquals(setregCalls[0].args[1], "    function test() {\n      return 42;\n    }")
+    })
   })
 })

--- a/denops/haritsuke/types.ts
+++ b/denops/haritsuke/types.ts
@@ -24,6 +24,7 @@ export type HaritsukeConfig = {
   debug: boolean
   use_region_hl?: boolean
   region_hl_groupname?: string
+  smart_indent?: boolean
 }
 
 // Paste information for rounder

--- a/denops/haritsuke/utils/indent-adjuster.ts
+++ b/denops/haritsuke/utils/indent-adjuster.ts
@@ -1,0 +1,150 @@
+import type { VimApi } from "../vim/vim-api.ts"
+import type { DebugLogger } from "./debug-logger.ts"
+import type { PasteInfo } from "../types.ts"
+
+/**
+ * Detect the minimum common indent from lines
+ */
+export function detectMinIndent(lines: string[]): string {
+  let minIndent: string | null = null;
+  
+  for (const line of lines) {
+    // Skip empty lines
+    if (line.trim() === "") {
+      continue;
+    }
+    
+    // Extract leading whitespace
+    const match = line.match(/^(\s*)/);
+    if (!match) {
+      continue;
+    }
+    
+    const indent = match[1];
+    if (minIndent === null || indent.length < minIndent.length) {
+      minIndent = indent;
+    }
+  }
+  
+  return minIndent || "";
+}
+
+/**
+ * Generate indent text based on indent count and settings
+ */
+export function getIndentText(
+  indentCount: number,
+  shiftWidth: number,
+  useTab: boolean,
+): string {
+  if (indentCount === 0) {
+    return "";
+  }
+  
+  if (useTab) {
+    // Use tabs
+    return "\t".repeat(indentCount);
+  } else {
+    // Use spaces
+    return " ".repeat(indentCount * shiftWidth);
+  }
+}
+
+/**
+ * Adjust indent of lines based on base indent
+ */
+export function adjustIndent(lines: string[], baseIndent: string): string[] {
+  const minIndent = detectMinIndent(lines);
+  
+  return lines.map((line) => {
+    // Empty lines remain empty
+    if (line.trim() === "") {
+      return "";
+    }
+    
+    // Remove minimum indent and add base indent
+    if (line.startsWith(minIndent)) {
+      return baseIndent + line.slice(minIndent.length);
+    }
+    
+    // Fallback: just prepend base indent
+    return baseIndent + line;
+  });
+}
+
+/**
+ * Smart indent adjustment for pasted content
+ * Handles complex logic for determining appropriate indentation
+ */
+export async function adjustContentIndentSmart(
+  content: string,
+  pasteInfo: PasteInfo,
+  vimApi: VimApi,
+  logger?: DebugLogger | null,
+): Promise<string> {
+  try {
+    logger?.log("indent", "Starting smart indent adjustment", {
+      contentLength: content.length,
+      mode: pasteInfo.mode,
+    })
+
+    // Get the current line for indent reference
+    const currentLine = await vimApi.getline(".")
+    
+    // Detect base indent from current line
+    const baseIndentMatch = currentLine.match(/^(\s*)/)
+    const baseIndent = baseIndentMatch ? baseIndentMatch[1] : ""
+    
+    // If no indent on current line and pasting after (p), calculate expected indent
+    if (baseIndent === "" && pasteInfo.mode === "p") {
+      const nextLineNum = (await vimApi.line(".")) + 1
+      const shiftWidth = await vimApi.getwinvar(0, "&shiftwidth") as number
+      const expandTab = await vimApi.getwinvar(0, "&expandtab") as number
+      
+      // Calculate expected indent level using Vim's indent expression
+      const indentExpr = await vimApi.getbufvar(0, "&indentexpr") as string
+      let indentCount = 0
+      
+      if (indentExpr) {
+        // Use indentexpr if available
+        const tempContent = "temp"
+        await vimApi.cmd(`silent! normal! o${tempContent}`)
+        const indentWidth = await vimApi.eval(`indent(${nextLineNum})`) as number
+        await vimApi.cmd("silent! normal! u")
+        indentCount = Math.floor(indentWidth / shiftWidth)
+      }
+      
+      const newBaseIndent = getIndentText(indentCount, shiftWidth, expandTab === 0)
+      
+      // Adjust the content
+      const lines = content.split("\n")
+      const adjustedLines = adjustIndent(lines, newBaseIndent)
+      const adjustedContent = adjustedLines.join("\n")
+      
+      logger?.log("indent", "Adjusted with calculated indent", {
+        originalLength: content.length,
+        adjustedLength: adjustedContent.length,
+        baseIndent: newBaseIndent,
+      })
+      
+      return adjustedContent
+    } else {
+      // Adjust based on current line indent
+      const lines = content.split("\n")
+      const adjustedLines = adjustIndent(lines, baseIndent)
+      const adjustedContent = adjustedLines.join("\n")
+      
+      logger?.log("indent", "Adjusted with current line indent", {
+        originalLength: content.length,
+        adjustedLength: adjustedContent.length,
+        baseIndent,
+      })
+      
+      return adjustedContent
+    }
+  } catch (error) {
+    logger?.error("indent", "Smart indent adjustment failed", error)
+    // Return original content on error
+    return content
+  }
+}

--- a/denops/haritsuke/vim/vim-api.ts
+++ b/denops/haritsuke/vim/vim-api.ts
@@ -37,6 +37,8 @@ export type VimApi = {
   // Variable operations
   setGlobalVar: (name: string, value: unknown) => Promise<void>
   getGlobalVar: (name: string) => Promise<unknown>
+  getwinvar: (winnr: number, varname: string) => Promise<unknown>
+  getbufvar: (bufnr: number, varname: string) => Promise<unknown>
 }
 
 /**
@@ -99,6 +101,14 @@ export const createVimApi = (denops: Denops): VimApi => {
     getGlobalVar: async (name: string) => {
       return await vars.g.get(denops, name)
     },
+
+    getwinvar: async (winnr: number, varname: string) => {
+      return await fn.getwinvar(denops, winnr, varname)
+    },
+
+    getbufvar: async (bufnr: number, varname: string) => {
+      return await fn.getbufvar(denops, bufnr, varname)
+    },
   }
 }
 
@@ -138,6 +148,8 @@ export const createMockVimApi = (overrides: Partial<VimApi> = {}): VimApi => {
     },
     setGlobalVar: () => Promise.resolve(),
     getGlobalVar: () => Promise.resolve(undefined),
+    getwinvar: () => Promise.resolve(0),
+    getbufvar: () => Promise.resolve(""),
     ...overrides,
   }
 }

--- a/doc/haritsuke.txt
+++ b/doc/haritsuke.txt
@@ -113,6 +113,34 @@ MAPPINGS                                        *haritsuke-mappings*
     Replace operator. Use with motions to replace text with
     register content. For example, `griw` replaces inner word.
 
+                                                *<Plug>(haritsuke-toggle-smart-indent)*
+<Plug>(haritsuke-toggle-smart-indent)
+    Toggle smart indentation during active paste cycling.
+    When cycling through yank history with <C-p>/<C-n>,
+    use this mapping to toggle between adjusted and original
+    indentation. The change is applied immediately to the
+    current paste.
+
+                                                *<Plug>(haritsuke-p-no-smart-indent)*
+                                                *<Plug>(haritsuke-P-no-smart-indent)*
+                                                *<Plug>(haritsuke-gp-no-smart-indent)*
+                                                *<Plug>(haritsuke-gP-no-smart-indent)*
+<Plug>(haritsuke-p-no-smart-indent)
+<Plug>(haritsuke-P-no-smart-indent)
+<Plug>(haritsuke-gp-no-smart-indent)
+<Plug>(haritsuke-gP-no-smart-indent)
+    Same as the regular paste mappings, but temporarily disable
+    smart indentation for the paste operation. These mappings
+    are not bound by default. Use them when you need to paste
+    with the original indentation preserved.
+
+    Example mapping:
+>
+    " Use <Leader>p for paste without smart indent
+    nmap <Leader>p <Plug>(haritsuke-p-no-smart-indent)
+    nmap <Leader>P <Plug>(haritsuke-P-no-smart-indent)
+<
+
                                                 *haritsuke#is_active()*
 haritsuke#is_active()
     Returns 1 if paste cycling is currently active, 0 otherwise.
@@ -163,7 +191,8 @@ Configure haritsuke.vim by setting `g:haritsuke_config` dictionary:
       \ 'register_keys': 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"-=.:%/#*+~_',
       \ 'debug': v:false,
       \ 'use_region_hl': v:true,
-      \ 'region_hl_groupname': 'HaritsukeRegion'
+      \ 'region_hl_groupname': 'HaritsukeRegion',
+      \ 'smart_indent': v:true
       \ }
 <
 
@@ -196,6 +225,12 @@ use_region_hl                           *g:haritsuke_config.use_region_hl*
 region_hl_groupname                     *g:haritsuke_config.region_hl_groupname*
     Vim highlight group for paste region highlighting.
     Default: 'HaritsukeRegion'
+
+smart_indent                            *g:haritsuke_config.smart_indent*
+    Enable smart indentation adjustment for line-wise paste operations.
+    When enabled, automatically adjusts the indentation of pasted lines
+    to match the current context.
+    Default: v:true
 
 ==============================================================================
 HIGHLIGHTS                                      *haritsuke-highlights*

--- a/plugin/haritsuke.vim
+++ b/plugin/haritsuke.vim
@@ -35,6 +35,19 @@ nnoremap <silent> <Plug>(haritsuke-next) <Cmd>call haritsuke#cycle_next()<CR>
 nnoremap <silent> <Plug>(haritsuke-replace) <Cmd>set operatorfunc=haritsuke#replace_operator<CR>g@
 xnoremap <silent> <Plug>(haritsuke-replace) :<C-u>call haritsuke#replace_operator(visualmode(1))<CR>
 
+" Toggle smart indent
+nnoremap <silent> <Plug>(haritsuke-toggle-smart-indent) <Cmd>call haritsuke#toggle_smart_indent()<CR>
+
+" Paste without smart indent (not mapped by default)
+nnoremap <silent> <Plug>(haritsuke-p-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('p', 'n')<CR>
+nnoremap <silent> <Plug>(haritsuke-P-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('P', 'n')<CR>
+nnoremap <silent> <Plug>(haritsuke-gp-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('gp', 'n')<CR>
+nnoremap <silent> <Plug>(haritsuke-gP-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('gP', 'n')<CR>
+xnoremap <silent> <Plug>(haritsuke-p-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('p', 'v')<CR>
+xnoremap <silent> <Plug>(haritsuke-P-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('P', 'v')<CR>
+xnoremap <silent> <Plug>(haritsuke-gp-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('gp', 'v')<CR>
+xnoremap <silent> <Plug>(haritsuke-gP-no-smart-indent) <Cmd>call haritsuke#do_paste_no_smart_indent('gP', 'v')<CR>
+
 " Highlight group
 highlight default link HaritsukeRegion IncSearch
 


### PR DESCRIPTION
## Summary
- Implement smart indentation adjustment for line-wise paste operations
- Add toggle functionality to enable/disable smart indent during paste cycling
- Add comprehensive test coverage for the new features

## Details

### Smart Indentation
- Automatically adjusts the indentation of pasted lines to match the current cursor context
- Only applies to line-wise yanks (register type "V")
- Can be disabled via configuration `smart_indent: false`
- Preserves relative indentation within multi-line pastes

### Toggle Feature
- New mapping `<Plug>(haritsuke-toggle-smart-indent)` to toggle smart indent during active paste cycling
- Allows users to quickly switch between adjusted and original indentation while cycling through history
- Example mapping: `nmap <C-i> <Plug>(haritsuke-toggle-smart-indent)`

### Paste Without Smart Indent
- Added special mappings for pasting with original indentation preserved
- `<Plug>(haritsuke-p-no-smart-indent)` and related mappings
- Useful when you need the exact original formatting

### Test Coverage
- Added tests for indent adjustment logic
- Added tests for API endpoints (preparePaste with smart indent)
- Added tests for toggle functionality

## Configuration
```vim
let g:haritsuke_config = {
  \ 'smart_indent': v:true  " Enable smart indentation (default: true)
  \ }
```

## Breaking Changes
None - the feature is enabled by default but can be disabled via configuration.